### PR TITLE
Fix oom homer

### DIFF
--- a/JHaaS/ChIPseq/chipseq.snakemake
+++ b/JHaaS/ChIPseq/chipseq.snakemake
@@ -137,6 +137,8 @@ rule chipseq_homer:
     "env_chipseq.yaml"
   params:
     proxy=lambda wildcards: config['proxy'],
+  resources:
+    mem_mb="2000"
   shell:
     "findMotifsGenome.pl {input.peaks} hg19 {output} -mask 2>> {log}"
 

--- a/JHaaS/Genomics/genomics.snakemake
+++ b/JHaaS/Genomics/genomics.snakemake
@@ -1,4 +1,7 @@
-files = ['custom_track.bed', 'eden.gff']
+files = ['custom_track.bed', 
+         'eden.gff',
+	 'ucsc_table_chr22_CpGislands.fasta',
+	 'ucsc_table_clock_snps.tsv']
 rule files_genomics:
   input:
     ["../data/Genomics/%s" % f for f in files]


### PR DESCRIPTION
This PR should 
- request 2GB instead of the default 1GB for rule `chipseq_homer` to avoid OOM on Elenas end. Memory use was very close to 1GB in my hands.
- add copying of two additional example solution files