### PR TITLE
Add build action

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -31,8 +31,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: harbor.computational.bio.uni-giessen.de
-          username: ${{ vars.HARBOR_CB_USERNAME }}
-          password: ${{ secrets.HARBOR_CB_SECRET }}
+          username: ${{ vars.HARBOR_CB_USERNAME_test }}
+          password: ${{ secrets.HARBOR_CB_SECRET_test }}
 
       - name: Build JHaaS image and push to harbor.computational.bio.uni-giessen.de registry
         uses: docker/build-push-action@v6

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -1,0 +1,45 @@
+# todo: "make" files once and push around through artifacts!
+
+name: build_container
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+      - add_build-action
+
+jobs:
+  build_main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout teaching_MS-MO-ABS repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Read image version from dockerfile
+        id: vars
+        run: |
+          VERSION=$(head -n 1 JHaaS/jhaas.dockerfile | cut -d ":" -f 2- | tr -d " ")
+          echo "IMAGE_TAG=$VERSION" >> $GITHUB_ENV
+
+      - name: Login to computational.bio registry
+        uses: docker/login-action@v3
+        with:
+          registry: harbor.computational.bio.uni-giessen.de
+          username: ${{ vars.HARBOR_CB_USERNAME }}
+          password: ${{ secrets.HARBOR_CB_SECRET }}
+
+      - name: Build JHaaS image and push to harbor.computational.bio.uni-giessen.de registry
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          file: JHaaS/jhaas.dockerfile
+          tags: |
+            ghcr.io/${{ github.repository }}/${{ matrix.container }}:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ github.repository }}/${{ matrix.container }}:latest

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -46,5 +46,5 @@ jobs:
           push: true
           file: JHaaS/jhaas.dockerfile
           tags: |
-            harbor.computational.bio.uni-giessen.de/tinqiita/jhaas_msmoabs:${{ env.IMAGE_TAG }}
-            harbor.computational.bio.uni-giessen.de/tinqiita/jhaas_msmoabs:latest
+            harbor.computational.bio.uni-giessen.de/jhaas-notebooks/jhaas_msmoabs:${{ env.IMAGE_TAG }}
+            harbor.computational.bio.uni-giessen.de/jhaas-notebooks/jhaas_msmoabs:latest

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -34,10 +34,15 @@ jobs:
           username: ${{ vars.HARBOR_CB_USERNAME_test }}
           password: ${{ secrets.HARBOR_CB_SECRET_test }}
 
+      - name: prepare image context
+        run: |
+          mkdir img_context
+          cp Tour/env_tour.yaml RNAseq/env_rnaseq.yaml RNAseq/env_dge.yaml NGS/env_ngs.yaml ChIPseq/env_chipseq.yaml jhaas.dockerfile img_context/
+
       - name: Build JHaaS image and push to harbor.computational.bio.uni-giessen.de registry
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: img_context
           push: true
           file: JHaaS/jhaas.dockerfile
           tags: |

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -31,8 +31,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: harbor.computational.bio.uni-giessen.de
-          username: ${{ vars.HARBOR_CB_USERNAME_test }}
-          password: ${{ secrets.HARBOR_CB_SECRET_test }}
+          username: ${{ vars.HARBOR_CB_USERNAME }}
+          password: ${{ secrets.HARBOR_CB_SECRET }}
 
       - name: prepare image context
         run: |

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -41,5 +41,5 @@ jobs:
           push: true
           file: JHaaS/jhaas.dockerfile
           tags: |
-            ghcr.io/${{ github.repository }}/${{ matrix.container }}:${{ env.IMAGE_TAG }}
-            ghcr.io/${{ github.repository }}/${{ matrix.container }}:latest
+            harbor.computational.bio.uni-giessen.de/tinqiita/jhaas_msmoabs:${{ env.IMAGE_TAG }}
+            harbor.computational.bio.uni-giessen.de/tinqiita/jhaas_msmoabs:latest

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: prepare image context
         run: |
           mkdir img_context
-          cp Tour/env_tour.yaml RNAseq/env_rnaseq.yaml RNAseq/env_dge.yaml NGS/env_ngs.yaml ChIPseq/env_chipseq.yaml jhaas.dockerfile img_context/
+          cp JHaaS/Tour/env_tour.yaml JHaaS/RNAseq/env_rnaseq.yaml JHaaS/RNAseq/env_dge.yaml JHaaS/NGS/env_ngs.yaml JHaaS/ChIPseq/env_chipseq.yaml JHaaS/jhaas.dockerfile img_context/
 
       - name: Build JHaaS image and push to harbor.computational.bio.uni-giessen.de registry
         uses: docker/build-push-action@v6

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: prepare image context
         run: |
           mkdir img_context
-          cp JHaaS/Tour/env_tour.yaml JHaaS/RNAseq/env_rnaseq.yaml JHaaS/RNAseq/env_dge.yaml JHaaS/NGS/env_ngs.yaml JHaaS/ChIPseq/env_chipseq.yaml JHaaS/jhaas.dockerfile img_context/
+          cp JHaaS/bashrc JHaaS/Tour/env_tour.yaml JHaaS/RNAseq/env_rnaseq.yaml JHaaS/RNAseq/env_dge.yaml JHaaS/NGS/env_ngs.yaml JHaaS/ChIPseq/env_chipseq.yaml JHaaS/jhaas.dockerfile img_context/
 
       - name: Build JHaaS image and push to harbor.computational.bio.uni-giessen.de registry
         uses: docker/build-push-action@v6

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ images/keyboard_*.png
 
 JHaaS/no_backup/
 JHaaS/.snakemake/
+JHaaS/robot*.json

--- a/JHaaS/jhaas.dockerfile
+++ b/JHaaS/jhaas.dockerfile
@@ -78,6 +78,14 @@ RUN cd $CONDA_PREFIX/share/homer && mv data old_data && ln -s /Data/ChIPseq/home
 RUN sed 's#^ORGANISMS#ORGANISMS\nhuman\tv7.0\tHomo sapiens (human) accession and ontology information\thttp://homer.ucsd.edu/homer/data/organisms/human.v7.0.zip\tdata/accession/\t9606,NCBI Gene#' -i $CONDA_PREFIX/share/homer/config.txt
 RUN sed 's#^GENOMES#GENOMES\nhg19\tv7.0\thuman genome and annotation for UCSC hg19\thttp://homer.ucsd.edu/homer/data/genomes/hg19.v7.0.zip\tdata/genomes/hg19/\thuman,default#' -i $CONDA_PREFIX/share/homer/config.txt
 
+# re-install man. Unfortunately, this requires "unminimizing" the image
+USER root
+RUN yes | unminimize
+RUN apt-get update && \
+    apt-get install -y manpages manpages-posix man-db && \
+    mandb && \
+    rm -rf /var/lib/apt/lists/*
+
 # modify bash behaviour:
 #   - do NOT make machine name part of the prompt, as it is very length in JHaaS
 #   - append settings in file bashrc to the global bashrc file in the container

--- a/JHaaS/jhaas.dockerfile
+++ b/JHaaS/jhaas.dockerfile
@@ -1,3 +1,6 @@
+# VERSION: 0.5
+# ^^ version used by github action to determine image tag. Must be first line!
+
 # wie koennen die User untereinander Dateien austauschen?
 
 FROM quay.io/jupyter/scipy-notebook


### PR DESCRIPTION
this PR
- adds a github action workflow to automatically build the required Jupyter based image push's it to  harbour@computational.bio
- unminimizes the image to restore the "man" functionality, which is extensively used in the teaching curse (addressing issue #6 )